### PR TITLE
Align all PMIDs with real Linux PMDA assignments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,32 +94,31 @@ pmlogsynth --list-metrics
   PyYAML + pcp.pmi, three-tier test strategy, CI-first delivery
 
 <!-- MANUAL ADDITIONS START -->
-## PCP Metric PMIDs — macOS vs Linux
+## PCP Metric PMIDs — Aligned With Linux PMDA
+
+**All pmlogsynth PMIDs now match the real Linux PMDA assignments.** Domain 60 is used
+throughout (the invented domain 58 has been eliminated). Metric names also match
+(e.g. `disk.dev.aveq`, not `disk.dev.avg_qlen`).
 
 **macOS `pminfo` is useless for verifying Linux PMIDs.** macOS PCP uses domain 78 for
-nearly everything; Linux uses domain 60 (linux PMDA) and domain 58 (existing pmlogsynth
-convention for mem.util.*). Running `pminfo -d <metric>` on macOS either returns wrong
-domain numbers or "Unknown metric name" for Linux-only metrics.
+nearly everything. Always verify against the Linux PMDA source.
 
 **Authoritative source for Linux PMIDs:**
 `https://github.com/performancecopilot/pcp` → `src/pmdas/linux/pmda.c`
 
 Key cluster definitions (from `src/pmdas/linux/linux.h`):
 - `CLUSTER_STAT = 0` — `/proc/stat` (cpu, disk, scheduler, swap page counters)
-- `CLUSTER_MEMINFO = 1` — `/proc/meminfo` (mem.util.*, swap.used, mem.physmem)
+- `CLUSTER_MEMINFO = 1` — `/proc/meminfo` (mem.util.*, swap.used, mem.physmem, hinv.physmem)
 - `CLUSTER_LOADAVG = 2` — `/proc/loadavg`
+- `CLUSTER_NET_DEV = 3` — `/proc/net/dev` (network.interface.*, hinv.ninterface)
+- `CLUSTER_KERNEL_UNAME = 12` — `uname()` (kernel.uname.*)
 - `CLUSTER_VMSTAT = 28` — `/proc/vmstat` (mem.vmstat.pgpgin etc.)
-- `CLUSTER_FILESYS = 5` — mounted filesystems (NOT disk.dev.* — common mistake)
+- `CLUSTER_NET_ALL = 90` — network.all.* aggregates
 
-**Existing code deviates from real PMIDs — intentionally and safely.** pmlogsynth archives
-are self-contained: pmrep reads metrics by name via the archive's own PMNS. The PMID just
-needs to be unique within the archive, not match the live PMDA. Existing code uses:
-- Domain 58 cluster 0 for `mem.util.*` (real PMDA: domain 60 cluster 1) — works fine
-- Cluster 5 for `disk.dev.*` (real PMDA: cluster 0 = CLUSTER_STAT) — works fine
-
-**Convention for new metrics:** follow the existing code's cluster/domain conventions to
-maintain internal consistency. Pick item numbers that don't conflict with existing
-descriptors in the same (domain, cluster) pair.
+**Convention for new metrics:** look up the real Linux PMDA assignment in `pmda.c`
+and use the exact (domain, cluster, item) tuple. All pmlogsynth metrics should match
+real Linux hosts. If the item number cannot be determined from source (e.g. vmstat
+fields with dynamic ordering), use a reasonable convention and document it.
 
 **Linux verification command** (run on CI or a Linux box with PCP installed):
 ```bash

--- a/docs/superpowers/specs/2026-03-19-pmid-alignment-design.md
+++ b/docs/superpowers/specs/2026-03-19-pmid-alignment-design.md
@@ -1,0 +1,179 @@
+# Full PMID Alignment With Linux PMDA
+
+**Date:** 2026-03-19
+**Status:** Approved
+
+## Problem
+
+pmlogsynth aims to generate archives that mimic real Linux PCP hosts, but most
+metric PMIDs don't match the real Linux PMDA assignments. PR #11 fixed network
+PMIDs; this completes the job for all remaining domains.
+
+## Scope
+
+Fix 47 PMIDs across 5 domain modules + rename `disk.dev.avg_qlen` → `disk.dev.aveq`
+to match the real Linux metric name. No functional changes — only PMID tuples and
+one metric name.
+
+## Already Correct (no changes)
+
+- `kernel.all.load` — (60, 2, 0) matches CLUSTER_LOADAVG=2
+- `kernel.all.intr` — (60, 0, 12) matches CLUSTER_STAT item 12
+- `kernel.all.running` — (60, 0, 15) matches CLUSTER_STAT item 15
+- `kernel.all.blocked` — (60, 0, 16) matches CLUSTER_STAT item 16
+- `hinv.ncpu` — (60, 0, 32) matches CLUSTER_STAT item 32
+- `hinv.ndisk` — (60, 0, 33) matches CLUSTER_STAT item 33
+- `kernel.all.cpu.user` — (60, 0, 20)
+- `kernel.all.cpu.sys` — (60, 0, 22)
+- `kernel.all.cpu.wait.total` — (60, 0, 35)
+- `kernel.all.cpu.vuser` — (60, 0, 78)
+- `kernel.all.cpu.vnice` — (60, 0, 82)
+- `kernel.all.cpu.guest` — (60, 0, 60)
+- `kernel.all.cpu.guest_nice` — (60, 0, 81)
+- `kernel.all.cpu.intr` — (60, 0, 34)
+- All 12 `network.*` metrics (fixed in PR #11)
+
+## CPU Domain Corrections (cpu.py)
+
+| Metric | Old PMID | Corrected PMID | Source |
+|--------|----------|---------------|--------|
+| `kernel.all.cpu.idle` | (60, 0, 21) | (60, 0, 23) | CLUSTER_STAT item 23 |
+| `kernel.all.cpu.nice` | (60, 0, 27) | (60, 0, 21) | CLUSTER_STAT item 21 |
+| `kernel.all.cpu.steal` | (60, 0, 58) | (60, 0, 55) | CLUSTER_STAT item 55 |
+| `kernel.percpu.cpu.user` | (60, 10, 20) | (60, 0, 0) | CLUSTER_STAT item 0 |
+| `kernel.percpu.cpu.sys` | (60, 10, 22) | (60, 0, 2) | CLUSTER_STAT item 2 |
+| `kernel.percpu.cpu.idle` | (60, 10, 21) | (60, 0, 3) | CLUSTER_STAT item 3 |
+
+Note: percpu metrics move from invented cluster 10 to real CLUSTER_STAT=0.
+They share the same cluster as kernel.all.cpu.* — differentiated by indom
+(percpu has cpu_indom, all has indom=None), which is how the real PMDA works.
+
+## System Domain Corrections (system.py)
+
+| Metric | Old PMID | Corrected PMID | Source |
+|--------|----------|---------------|--------|
+| `kernel.all.pswitch` | (60, 0, 7) | (60, 0, 13) | CLUSTER_STAT item 13 |
+
+## Disk Domain Corrections (disk.py)
+
+All 16 disk metrics move from invented clusters 4/5 to real CLUSTER_STAT=0.
+
+**Aggregate (disk.all.*) — old cluster 4 → cluster 0:**
+
+| Metric | Old PMID | Corrected PMID |
+|--------|----------|---------------|
+| `disk.all.read` | (60, 4, 0) | (60, 0, 24) |
+| `disk.all.write` | (60, 4, 1) | (60, 0, 25) |
+| `disk.all.read_bytes` | (60, 4, 5) | (60, 0, 41) |
+| `disk.all.write_bytes` | (60, 4, 6) | (60, 0, 42) |
+
+**Per-device (disk.dev.*) — old cluster 5 → cluster 0:**
+
+| Metric | Old PMID | Corrected PMID |
+|--------|----------|---------------|
+| `disk.dev.read` | (60, 5, 0) | (60, 0, 4) |
+| `disk.dev.write` | (60, 5, 1) | (60, 0, 5) |
+| `disk.dev.read_merge` | (60, 5, 2) | (60, 0, 49) |
+| `disk.dev.write_merge` | (60, 5, 3) | (60, 0, 50) |
+| `disk.dev.read_bytes` | (60, 5, 5) | (60, 0, 38) |
+| `disk.dev.write_bytes` | (60, 5, 6) | (60, 0, 39) |
+| `disk.dev.blkread` | (60, 5, 7) | (60, 0, 6) |
+| `disk.dev.blkwrite` | (60, 5, 8) | (60, 0, 7) |
+| `disk.dev.read_rawactive` | (60, 5, 9) | (60, 0, 72) |
+| `disk.dev.write_rawactive` | (60, 5, 10) | (60, 0, 73) |
+| `disk.dev.avactive` | (60, 5, 12) | (60, 0, 46) |
+| `disk.dev.avg_qlen` **→ `disk.dev.aveq`** | (60, 5, 11) | (60, 0, 47) |
+
+**Metric rename:** `disk.dev.avg_qlen` → `disk.dev.aveq` to match the real Linux
+metric name (`disk.dev.aveq` in the linux PMDA). Touches: disk.py, cli.py,
+test_domain_disk.py, test_list_metrics.py, test_cli.py, man page.
+
+## Memory Domain Corrections (memory.py)
+
+All 13 memory metrics move from invented domain 58 to real domain 60.
+
+**mem.util.* and mem.physmem — domain 58 cluster 0 → domain 60 CLUSTER_MEMINFO=1:**
+
+| Metric | Old PMID | Corrected PMID |
+|--------|----------|---------------|
+| `mem.physmem` | (58, 0, 0) | (60, 1, 0) |
+| `mem.util.used` | (58, 0, 6) | (60, 1, 1) |
+| `mem.util.free` | (58, 0, 2) | (60, 1, 2) |
+| `mem.util.bufmem` | (58, 0, 4) | (60, 1, 4) |
+| `mem.util.cached` | (58, 0, 13) | (60, 1, 5) |
+| `mem.util.active` | (58, 0, 15) | (60, 1, 14) |
+| `mem.util.inactive` | (58, 0, 16) | (60, 1, 15) |
+| `mem.util.slab` | (58, 0, 12) | (60, 1, 25) |
+
+**swap.used — domain 58 cluster 1 → domain 60 CLUSTER_MEMINFO=1:**
+
+| Metric | Old PMID | Corrected PMID |
+|--------|----------|---------------|
+| `swap.used` | (58, 1, 0) | (60, 1, 7) |
+
+**swap.pagesin/out — domain 58 cluster 1 → domain 60 CLUSTER_STAT=0:**
+
+| Metric | Old PMID | Corrected PMID |
+|--------|----------|---------------|
+| `swap.pagesin` | (58, 1, 1) | (60, 0, 8) |
+| `swap.pagesout` | (58, 1, 2) | (60, 0, 9) |
+
+**mem.vmstat.* — domain 58 cluster 2 → domain 60 CLUSTER_VMSTAT=28:**
+
+| Metric | Old PMID | Corrected PMID | Note |
+|--------|----------|---------------|------|
+| `mem.vmstat.pgpgin` | (58, 2, 0) | (60, 28, 0) | Item from /proc/vmstat field ordering |
+| `mem.vmstat.pgpgout` | (58, 2, 1) | (60, 28, 1) | Item from /proc/vmstat field ordering |
+
+Note: vmstat items are dynamically assigned in real PCP from /proc/vmstat field
+ordering. Items 0/1 are a reasonable convention — the exact values don't matter
+for self-contained archives, and we cannot determine the real assignment from source.
+
+## Metadata Domain Corrections (metadata.py)
+
+| Metric | Old PMID | Corrected PMID | Source |
+|--------|----------|---------------|--------|
+| `kernel.uname.sysname` | (60, 9, 0) | (60, 12, 2) | CLUSTER_KERNEL_UNAME=12 |
+| `kernel.uname.nodename` | (60, 9, 1) | (60, 12, 4) | CLUSTER_KERNEL_UNAME=12 |
+| `kernel.uname.release` | (60, 9, 2) | (60, 12, 0) | CLUSTER_KERNEL_UNAME=12 |
+| `kernel.uname.version` | (60, 9, 3) | (60, 12, 1) | CLUSTER_KERNEL_UNAME=12 |
+| `kernel.uname.machine` | (60, 9, 4) | (60, 12, 3) | CLUSTER_KERNEL_UNAME=12 |
+| `kernel.uname.distro` | (60, 9, 5) | (60, 12, 7) | CLUSTER_KERNEL_UNAME=12 |
+| `hinv.physmem` | (60, 0, 36) | (60, 1, 9) | CLUSTER_MEMINFO=1 |
+| `hinv.pagesize` | (60, 0, 37) | (60, 1, 11) | CLUSTER_MEMINFO=1 |
+| `hinv.ninterface` | (60, 0, 38) | (60, 3, 27) | CLUSTER_NET_DEV=3 |
+
+Note: `hinv.ndisk` (60, 0, 33) is already correct — no change needed.
+
+## CLAUDE.md Update
+
+The "PCP Metric PMIDs" section of CLAUDE.md must be updated to reflect that
+pmlogsynth now aligns with real Linux PMDA assignments. The "existing code
+deviates from real PMIDs — intentionally and safely" note should be replaced
+with documentation of the alignment approach and the vmstat caveat.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `pmlogsynth/domains/cpu.py` | Fix 6 PMIDs |
+| `pmlogsynth/domains/system.py` | Fix 1 PMID |
+| `pmlogsynth/domains/disk.py` | Fix 16 PMIDs, rename avg_qlen→aveq |
+| `pmlogsynth/domains/memory.py` | Fix 13 PMIDs (domain 58→60) |
+| `pmlogsynth/domains/metadata.py` | Fix 9 PMIDs (uname cluster 9→12, hinv fixes) |
+| `pmlogsynth/cli.py` | Rename disk.dev.avg_qlen→disk.dev.aveq |
+| `tests/unit/test_domain_cpu.py` | Update PMID assertions |
+| `tests/unit/test_domain_disk.py` | Update PMID assertions + rename |
+| `tests/unit/test_domain_memory.py` | Update PMID assertions |
+| `tests/unit/test_domain_metadata.py` | Update PMID assertions |
+| `tests/unit/test_domain_system.py` | Update PMID assertions if present |
+| `tests/unit/test_list_metrics.py` | Rename avg_qlen→aveq |
+| `tests/unit/test_cli.py` | Rename if referenced |
+| `man/pmlogsynth.1` | Rename avg_qlen→aveq |
+| `CLAUDE.md` | Update PMID documentation |
+
+## PMID Source
+
+All corrected values from: `https://github.com/performancecopilot/pcp` →
+`src/pmdas/linux/linux.h` (cluster constants) and `src/pmdas/linux/pmda.c`
+(metric table PMDA_PMID entries).

--- a/pmlogsynth/cli.py
+++ b/pmlogsynth/cli.py
@@ -17,7 +17,7 @@ _ALL_METRIC_NAMES: List[str] = [
     "disk.all.write",
     "disk.all.write_bytes",
     "disk.dev.avactive",
-    "disk.dev.avg_qlen",
+    "disk.dev.aveq",
     "disk.dev.blkread",
     "disk.dev.blkwrite",
     "disk.dev.read",

--- a/pmlogsynth/domains/cpu.py
+++ b/pmlogsynth/domains/cpu.py
@@ -58,7 +58,7 @@ class CpuMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="kernel.all.cpu.idle",
-                pmid=(60, 0, 21),
+                pmid=(60, 0, 23),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_COUNTER,
@@ -74,7 +74,7 @@ class CpuMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="kernel.all.cpu.steal",
-                pmid=(60, 0, 58),
+                pmid=(60, 0, 55),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_COUNTER,
@@ -83,7 +83,7 @@ class CpuMetricModel(MetricModel):
             # Sub-metric carves from user bucket
             MetricDescriptor(
                 name="kernel.all.cpu.nice",
-                pmid=(60, 0, 27),
+                pmid=(60, 0, 21),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_COUNTER,
@@ -143,7 +143,7 @@ class CpuMetricModel(MetricModel):
             # Per-CPU metrics
             MetricDescriptor(
                 name="kernel.percpu.cpu.user",
-                pmid=(60, 10, 20),
+                pmid=(60, 0, 0),
                 type_code=PM_TYPE_U64,
                 indom=cpu_indom,
                 sem=PM_SEM_COUNTER,
@@ -151,7 +151,7 @@ class CpuMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="kernel.percpu.cpu.sys",
-                pmid=(60, 10, 22),
+                pmid=(60, 0, 2),
                 type_code=PM_TYPE_U64,
                 indom=cpu_indom,
                 sem=PM_SEM_COUNTER,
@@ -159,7 +159,7 @@ class CpuMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="kernel.percpu.cpu.idle",
-                pmid=(60, 10, 21),
+                pmid=(60, 0, 3),
                 type_code=PM_TYPE_U64,
                 indom=cpu_indom,
                 sem=PM_SEM_COUNTER,

--- a/pmlogsynth/domains/disk.py
+++ b/pmlogsynth/domains/disk.py
@@ -36,7 +36,7 @@ class DiskMetricModel(MetricModel):
             # Aggregate metrics (disk.all.*)
             MetricDescriptor(
                 name="disk.all.read",
-                pmid=(60, 4, 0),
+                pmid=(60, 0, 24),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_COUNTER,
@@ -44,7 +44,7 @@ class DiskMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="disk.all.write",
-                pmid=(60, 4, 1),
+                pmid=(60, 0, 25),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_COUNTER,
@@ -52,7 +52,7 @@ class DiskMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="disk.all.read_bytes",
-                pmid=(60, 4, 5),
+                pmid=(60, 0, 41),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_COUNTER,
@@ -60,7 +60,7 @@ class DiskMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="disk.all.write_bytes",
-                pmid=(60, 4, 6),
+                pmid=(60, 0, 42),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_COUNTER,
@@ -69,7 +69,7 @@ class DiskMetricModel(MetricModel):
             # Existing per-device metrics
             MetricDescriptor(
                 name="disk.dev.read_bytes",
-                pmid=(60, 5, 5),
+                pmid=(60, 0, 38),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -77,7 +77,7 @@ class DiskMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="disk.dev.write_bytes",
-                pmid=(60, 5, 6),
+                pmid=(60, 0, 39),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -86,7 +86,7 @@ class DiskMetricModel(MetricModel):
             # New per-device IOPS counters
             MetricDescriptor(
                 name="disk.dev.read",
-                pmid=(60, 5, 0),
+                pmid=(60, 0, 4),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -94,7 +94,7 @@ class DiskMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="disk.dev.write",
-                pmid=(60, 5, 1),
+                pmid=(60, 0, 5),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -102,7 +102,7 @@ class DiskMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="disk.dev.read_merge",
-                pmid=(60, 5, 2),
+                pmid=(60, 0, 49),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -110,7 +110,7 @@ class DiskMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="disk.dev.write_merge",
-                pmid=(60, 5, 3),
+                pmid=(60, 0, 50),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -119,7 +119,7 @@ class DiskMetricModel(MetricModel):
             # New sector counters
             MetricDescriptor(
                 name="disk.dev.blkread",
-                pmid=(60, 5, 7),
+                pmid=(60, 0, 6),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -127,7 +127,7 @@ class DiskMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="disk.dev.blkwrite",
-                pmid=(60, 5, 8),
+                pmid=(60, 0, 7),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -136,7 +136,7 @@ class DiskMetricModel(MetricModel):
             # I/O time counters (milliseconds)
             MetricDescriptor(
                 name="disk.dev.read_rawactive",
-                pmid=(60, 5, 9),
+                pmid=(60, 0, 72),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -144,7 +144,7 @@ class DiskMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="disk.dev.write_rawactive",
-                pmid=(60, 5, 10),
+                pmid=(60, 0, 73),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -152,8 +152,8 @@ class DiskMetricModel(MetricModel):
             ),
             # Queue length instant (double)
             MetricDescriptor(
-                name="disk.dev.avg_qlen",
-                pmid=(60, 5, 11),
+                name="disk.dev.aveq",
+                pmid=(60, 0, 47),
                 type_code=PM_TYPE_DOUBLE,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_INSTANT,
@@ -162,7 +162,7 @@ class DiskMetricModel(MetricModel):
             # Active time counter
             MetricDescriptor(
                 name="disk.dev.avactive",
-                pmid=(60, 5, 12),
+                pmid=(60, 0, 46),
                 type_code=PM_TYPE_U64,
                 indom=_DISK_INDOM,
                 sem=PM_SEM_COUNTER,
@@ -226,7 +226,7 @@ class DiskMetricModel(MetricModel):
         dev_blkwrite: Dict[Optional[str], Any] = {}
         dev_read_rawactive: Dict[Optional[str], Any] = {}
         dev_write_rawactive: Dict[Optional[str], Any] = {}
-        dev_avg_qlen: Dict[Optional[str], Any] = {}
+        dev_aveq: Dict[Optional[str], Any] = {}
         dev_avactive: Dict[Optional[str], Any] = {}
 
         if num_disks > 0:
@@ -246,7 +246,7 @@ class DiskMetricModel(MetricModel):
             per_dev_write_raw_ms = (per_dev_write_bytes * 0.8 / (1024 * 1024)) * 1000
 
             # Queue length: proportional to combined throughput
-            avg_qlen_val = (read_mbps + write_mbps) / 100.0 / num_disks
+            aveq_val = (read_mbps + write_mbps) / 100.0 / num_disks
 
             for dev in hardware.disks:
                 n = dev.name
@@ -280,7 +280,7 @@ class DiskMetricModel(MetricModel):
                 dev_write_rawactive[n] = sampler.accumulate(
                     "disk.dev.write_rawactive." + n, per_dev_write_raw_ms
                 )
-                dev_avg_qlen[n] = avg_qlen_val
+                dev_aveq[n] = aveq_val
                 raw_active_ms = per_dev_read_raw_ms + per_dev_write_raw_ms
                 dev_avactive[n] = sampler.accumulate(
                     "disk.dev.avactive." + n, raw_active_ms
@@ -296,7 +296,7 @@ class DiskMetricModel(MetricModel):
         result["disk.dev.blkwrite"] = dev_blkwrite
         result["disk.dev.read_rawactive"] = dev_read_rawactive
         result["disk.dev.write_rawactive"] = dev_write_rawactive
-        result["disk.dev.avg_qlen"] = dev_avg_qlen
+        result["disk.dev.aveq"] = dev_aveq
         result["disk.dev.avactive"] = dev_avactive
 
         return result

--- a/pmlogsynth/domains/memory.py
+++ b/pmlogsynth/domains/memory.py
@@ -32,7 +32,7 @@ class MemoryMetricModel(MetricModel):
             # Existing metrics
             MetricDescriptor(
                 name="mem.util.used",
-                pmid=(58, 0, 6),
+                pmid=(60, 1, 1),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_INSTANT,
@@ -40,7 +40,7 @@ class MemoryMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="mem.util.free",
-                pmid=(58, 0, 2),
+                pmid=(60, 1, 2),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_INSTANT,
@@ -48,7 +48,7 @@ class MemoryMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="mem.util.cached",
-                pmid=(58, 0, 13),
+                pmid=(60, 1, 5),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_INSTANT,
@@ -56,7 +56,7 @@ class MemoryMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="mem.util.bufmem",
-                pmid=(58, 0, 4),
+                pmid=(60, 1, 4),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_INSTANT,
@@ -64,16 +64,16 @@ class MemoryMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="mem.physmem",
-                pmid=(58, 0, 0),
+                pmid=(60, 1, 0),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_DISCRETE,
                 units=UNITS_KBYTE,
             ),
-            # New instant metrics
+            # New instant metrics — CLUSTER_MEMINFO (domain 60, cluster 1)
             MetricDescriptor(
                 name="mem.util.active",
-                pmid=(58, 0, 15),
+                pmid=(60, 1, 14),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_INSTANT,
@@ -81,7 +81,7 @@ class MemoryMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="mem.util.inactive",
-                pmid=(58, 0, 16),
+                pmid=(60, 1, 15),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_INSTANT,
@@ -89,16 +89,16 @@ class MemoryMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="mem.util.slab",
-                pmid=(58, 0, 12),
+                pmid=(60, 1, 25),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_INSTANT,
                 units=UNITS_KBYTE,
             ),
-            # Swap metrics (cluster 1)
+            # Swap metrics — swap.used in CLUSTER_MEMINFO; pages in CLUSTER_STAT
             MetricDescriptor(
                 name="swap.used",
-                pmid=(58, 1, 0),
+                pmid=(60, 1, 7),
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_INSTANT,
@@ -106,7 +106,7 @@ class MemoryMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="swap.pagesin",
-                pmid=(58, 1, 1),
+                pmid=(60, 0, 8),
                 type_code=PM_TYPE_32,
                 indom=None,
                 sem=PM_SEM_COUNTER,
@@ -114,16 +114,16 @@ class MemoryMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="swap.pagesout",
-                pmid=(58, 1, 2),
+                pmid=(60, 0, 9),
                 type_code=PM_TYPE_32,
                 indom=None,
                 sem=PM_SEM_COUNTER,
                 units=UNITS_COUNT,
             ),
-            # Paging metrics (cluster 2)
+            # Paging metrics — CLUSTER_VMSTAT (domain 60, cluster 28)
             MetricDescriptor(
                 name="mem.vmstat.pgpgin",
-                pmid=(58, 2, 0),
+                pmid=(60, 28, 0),
                 type_code=PM_TYPE_U32,
                 indom=None,
                 sem=PM_SEM_COUNTER,
@@ -131,7 +131,7 @@ class MemoryMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="mem.vmstat.pgpgout",
-                pmid=(58, 2, 1),
+                pmid=(60, 28, 1),
                 type_code=PM_TYPE_U32,
                 indom=None,
                 sem=PM_SEM_COUNTER,

--- a/pmlogsynth/domains/metadata.py
+++ b/pmlogsynth/domains/metadata.py
@@ -22,18 +22,16 @@ from pmlogsynth.sampler import ValueSampler
 # Units: megabytes — (dimSpace=1, dimTime=0, dimCount=0, scaleSpace=PM_SPACE_MBYTE, 0, 0)
 _UNITS_MBYTE = (1, 0, 0, 2, 0, 0)
 
-# PMID cluster 9 — kernel.uname.* in the linux PMDA uses cluster 9
-_UNAME_CLUSTER = 9
-
 
 class MetadataMetricModel(MetricModel):
     """Generates kernel.uname.* and hinv.* discrete metadata metrics."""
 
     def metric_descriptors(self, hardware: HardwareProfile) -> List[MetricDescriptor]:
         return [
+            # kernel.uname.* — domain 60, CLUSTER_KERNEL_UNAME=12, items per linux PMDA
             MetricDescriptor(
                 name="kernel.uname.sysname",
-                pmid=(60, _UNAME_CLUSTER, 0),
+                pmid=(60, 12, 2),
                 type_code=PM_TYPE_STRING,
                 indom=None,
                 sem=PM_SEM_DISCRETE,
@@ -42,7 +40,7 @@ class MetadataMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="kernel.uname.nodename",
-                pmid=(60, _UNAME_CLUSTER, 1),
+                pmid=(60, 12, 4),
                 type_code=PM_TYPE_STRING,
                 indom=None,
                 sem=PM_SEM_DISCRETE,
@@ -51,7 +49,7 @@ class MetadataMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="kernel.uname.release",
-                pmid=(60, _UNAME_CLUSTER, 2),
+                pmid=(60, 12, 0),
                 type_code=PM_TYPE_STRING,
                 indom=None,
                 sem=PM_SEM_DISCRETE,
@@ -60,7 +58,7 @@ class MetadataMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="kernel.uname.version",
-                pmid=(60, _UNAME_CLUSTER, 3),
+                pmid=(60, 12, 1),
                 type_code=PM_TYPE_STRING,
                 indom=None,
                 sem=PM_SEM_DISCRETE,
@@ -69,7 +67,7 @@ class MetadataMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="kernel.uname.machine",
-                pmid=(60, _UNAME_CLUSTER, 4),
+                pmid=(60, 12, 3),
                 type_code=PM_TYPE_STRING,
                 indom=None,
                 sem=PM_SEM_DISCRETE,
@@ -78,16 +76,17 @@ class MetadataMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="kernel.uname.distro",
-                pmid=(60, _UNAME_CLUSTER, 5),
+                pmid=(60, 12, 7),
                 type_code=PM_TYPE_STRING,
                 indom=None,
                 sem=PM_SEM_DISCRETE,
                 units=UNITS_NONE,
                 is_discrete=True,
             ),
+            # hinv.* — domain 60; clusters per linux PMDA
             MetricDescriptor(
                 name="hinv.ndisk",
-                pmid=(60, 0, 33),
+                pmid=(60, 0, 33),          # CLUSTER_STAT=0 — already correct
                 type_code=PM_TYPE_U32,
                 indom=None,
                 sem=PM_SEM_DISCRETE,
@@ -96,7 +95,7 @@ class MetadataMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="hinv.physmem",
-                pmid=(60, 0, 36),
+                pmid=(60, 1, 9),           # CLUSTER_MEMINFO=1
                 type_code=PM_TYPE_U64,
                 indom=None,
                 sem=PM_SEM_DISCRETE,
@@ -105,7 +104,7 @@ class MetadataMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="hinv.pagesize",
-                pmid=(60, 0, 37),
+                pmid=(60, 1, 11),          # CLUSTER_MEMINFO=1
                 type_code=PM_TYPE_U32,
                 indom=None,
                 sem=PM_SEM_DISCRETE,
@@ -114,7 +113,7 @@ class MetadataMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="hinv.ninterface",
-                pmid=(60, 0, 38),
+                pmid=(60, 3, 27),          # CLUSTER_NET_DEV=3
                 type_code=PM_TYPE_U32,
                 indom=None,
                 sem=PM_SEM_DISCRETE,

--- a/pmlogsynth/domains/system.py
+++ b/pmlogsynth/domains/system.py
@@ -52,7 +52,7 @@ class SystemMetricModel(MetricModel):
             ),
             MetricDescriptor(
                 name="kernel.all.pswitch",
-                pmid=(60, 0, 7),
+                pmid=(60, 0, 13),
                 type_code=PM_TYPE_U32,
                 indom=None,
                 sem=PM_SEM_COUNTER,

--- a/tests/unit/test_domain_cpu.py
+++ b/tests/unit/test_domain_cpu.py
@@ -98,12 +98,12 @@ def test_descriptor_pmids() -> None:
 
     assert descriptors["kernel.all.cpu.user"].pmid == (60, 0, 20)
     assert descriptors["kernel.all.cpu.sys"].pmid == (60, 0, 22)
-    assert descriptors["kernel.all.cpu.idle"].pmid == (60, 0, 21)
+    assert descriptors["kernel.all.cpu.idle"].pmid == (60, 0, 23)
     assert descriptors["kernel.all.cpu.wait.total"].pmid == (60, 0, 35)
-    assert descriptors["kernel.all.cpu.steal"].pmid == (60, 0, 58)
-    assert descriptors["kernel.percpu.cpu.user"].pmid == (60, 10, 20)
-    assert descriptors["kernel.percpu.cpu.sys"].pmid == (60, 10, 22)
-    assert descriptors["kernel.percpu.cpu.idle"].pmid == (60, 10, 21)
+    assert descriptors["kernel.all.cpu.steal"].pmid == (60, 0, 55)
+    assert descriptors["kernel.percpu.cpu.user"].pmid == (60, 0, 0)
+    assert descriptors["kernel.percpu.cpu.sys"].pmid == (60, 0, 2)
+    assert descriptors["kernel.percpu.cpu.idle"].pmid == (60, 0, 3)
 
 
 def test_descriptor_type_and_sem() -> None:
@@ -519,7 +519,7 @@ def test_new_sub_metric_pmids() -> None:
     model = CpuMetricModel()
     hw = make_hw(cpus=4)
     desc = {d.name: d for d in model.metric_descriptors(hw)}
-    assert desc["kernel.all.cpu.nice"].pmid == (60, 0, 27)
+    assert desc["kernel.all.cpu.nice"].pmid == (60, 0, 21)
     assert desc["kernel.all.cpu.vuser"].pmid == (60, 0, 78)
     assert desc["kernel.all.cpu.vnice"].pmid == (60, 0, 82)
     assert desc["kernel.all.cpu.intr"].pmid == (60, 0, 34)

--- a/tests/unit/test_domain_disk.py
+++ b/tests/unit/test_domain_disk.py
@@ -58,7 +58,7 @@ class TestMetricDescriptors:
             "disk.dev.blkwrite",
             "disk.dev.read_rawactive",
             "disk.dev.write_rawactive",
-            "disk.dev.avg_qlen",
+            "disk.dev.aveq",
             "disk.dev.avactive",
         ):
             assert expected in names, "Missing descriptor: {}".format(expected)
@@ -71,7 +71,7 @@ class TestMetricDescriptors:
                 "disk.dev.read", "disk.dev.write", "disk.dev.read_merge",
                 "disk.dev.write_merge", "disk.dev.blkread", "disk.dev.blkwrite",
                 "disk.dev.read_rawactive", "disk.dev.write_rawactive",
-                "disk.dev.avg_qlen", "disk.dev.avactive",
+                "disk.dev.aveq", "disk.dev.avactive",
             ):
                 assert d.indom == (60, 1), f"{d.name}: expected indom (60,1)"
 
@@ -87,27 +87,27 @@ class TestMetricDescriptors:
             assert desc[name].sem == PM_SEM_COUNTER, f"{name}: expected PM_SEM_COUNTER"
             assert desc[name].type_code == PM_TYPE_U64, f"{name}: expected PM_TYPE_U64"
 
-    def test_avg_qlen_is_double_instant(self) -> None:
+    def test_aveq_is_double_instant(self) -> None:
         model = DiskMetricModel()
         hw = _make_hw()
         desc = {d.name: d for d in model.metric_descriptors(hw)}
-        assert desc["disk.dev.avg_qlen"].sem == PM_SEM_INSTANT
-        assert desc["disk.dev.avg_qlen"].type_code == PM_TYPE_DOUBLE
+        assert desc["disk.dev.aveq"].sem == PM_SEM_INSTANT
+        assert desc["disk.dev.aveq"].type_code == PM_TYPE_DOUBLE
 
     def test_new_pmids(self) -> None:
         model = DiskMetricModel()
         hw = _make_hw()
         desc = {d.name: d for d in model.metric_descriptors(hw)}
-        assert desc["disk.dev.read"].pmid == (60, 5, 0)
-        assert desc["disk.dev.write"].pmid == (60, 5, 1)
-        assert desc["disk.dev.read_merge"].pmid == (60, 5, 2)
-        assert desc["disk.dev.write_merge"].pmid == (60, 5, 3)
-        assert desc["disk.dev.blkread"].pmid == (60, 5, 7)
-        assert desc["disk.dev.blkwrite"].pmid == (60, 5, 8)
-        assert desc["disk.dev.read_rawactive"].pmid == (60, 5, 9)
-        assert desc["disk.dev.write_rawactive"].pmid == (60, 5, 10)
-        assert desc["disk.dev.avg_qlen"].pmid == (60, 5, 11)
-        assert desc["disk.dev.avactive"].pmid == (60, 5, 12)
+        assert desc["disk.dev.read"].pmid == (60, 0, 4)
+        assert desc["disk.dev.write"].pmid == (60, 0, 5)
+        assert desc["disk.dev.read_merge"].pmid == (60, 0, 49)
+        assert desc["disk.dev.write_merge"].pmid == (60, 0, 50)
+        assert desc["disk.dev.blkread"].pmid == (60, 0, 6)
+        assert desc["disk.dev.blkwrite"].pmid == (60, 0, 7)
+        assert desc["disk.dev.read_rawactive"].pmid == (60, 0, 72)
+        assert desc["disk.dev.write_rawactive"].pmid == (60, 0, 73)
+        assert desc["disk.dev.aveq"].pmid == (60, 0, 47)
+        assert desc["disk.dev.avactive"].pmid == (60, 0, 46)
 
     def test_aggregate_metrics_have_no_indom(self) -> None:
         model = DiskMetricModel()
@@ -127,12 +127,12 @@ class TestMetricDescriptors:
         model = DiskMetricModel()
         hw = _make_hw()
         by_name = {d.name: d for d in model.metric_descriptors(hw)}
-        assert by_name["disk.all.read"].pmid == (60, 4, 0)
-        assert by_name["disk.all.write"].pmid == (60, 4, 1)
-        assert by_name["disk.all.read_bytes"].pmid == (60, 4, 5)
-        assert by_name["disk.all.write_bytes"].pmid == (60, 4, 6)
-        assert by_name["disk.dev.read_bytes"].pmid == (60, 5, 5)
-        assert by_name["disk.dev.write_bytes"].pmid == (60, 5, 6)
+        assert by_name["disk.all.read"].pmid == (60, 0, 24)
+        assert by_name["disk.all.write"].pmid == (60, 0, 25)
+        assert by_name["disk.all.read_bytes"].pmid == (60, 0, 41)
+        assert by_name["disk.all.write_bytes"].pmid == (60, 0, 42)
+        assert by_name["disk.dev.read_bytes"].pmid == (60, 0, 38)
+        assert by_name["disk.dev.write_bytes"].pmid == (60, 0, 39)
 
 
 class TestPerDeviceInstances:
@@ -387,7 +387,7 @@ class TestNewDiskMetrics:
             "disk.dev.read_merge", "disk.dev.write_merge",
             "disk.dev.blkread", "disk.dev.blkwrite",
             "disk.dev.read_rawactive", "disk.dev.write_rawactive",
-            "disk.dev.avg_qlen", "disk.dev.avactive",
+            "disk.dev.aveq", "disk.dev.avactive",
         ):
             assert name in result, "Missing metric: {}".format(name)
 
@@ -423,15 +423,15 @@ class TestNewDiskMetrics:
         expected = int(1.0 * 1024 * 1024 * 60 / 512)
         assert result["disk.dev.blkread"]["sda"] == expected
 
-    def test_avg_qlen_is_float(self) -> None:
-        """disk.dev.avg_qlen must be a float value."""
+    def test_aveq_is_float(self) -> None:
+        """disk.dev.aveq must be a float value."""
         model = DiskMetricModel()
         hw = _make_hw()
         sampler = _make_sampler()
         stressor = DiskStressor(read_mbps=100.0, write_mbps=50.0)
         result = model.compute(stressor, hw, interval=60, sampler=sampler)
-        for val in result["disk.dev.avg_qlen"].values():
-            assert isinstance(val, float), "avg_qlen should be float, got {}".format(type(val))
+        for val in result["disk.dev.aveq"].values():
+            assert isinstance(val, float), "aveq should be float, got {}".format(type(val))
 
     def test_new_counters_accumulate_monotonically(self) -> None:
         """New counter metrics (read, write, blkread) increase across ticks."""
@@ -475,7 +475,7 @@ class TestNewDiskMetrics:
         for name in (
             "disk.dev.read", "disk.dev.write",
             "disk.dev.blkread", "disk.dev.blkwrite",
-            "disk.dev.avg_qlen", "disk.dev.avactive",
+            "disk.dev.aveq", "disk.dev.avactive",
         ):
             for val in result[name].values():
                 assert val == 0 or val == 0.0, "{} should be 0 with zero I/O, got {}".format(

--- a/tests/unit/test_domain_memory.py
+++ b/tests/unit/test_domain_memory.py
@@ -214,11 +214,11 @@ def test_metric_descriptors_pmids():
     model = make_model()
     descriptors = model.metric_descriptors(hw)
     pmid_map = {d.name: d.pmid for d in descriptors}
-    assert pmid_map["mem.util.used"] == (58, 0, 6)
-    assert pmid_map["mem.util.free"] == (58, 0, 2)
-    assert pmid_map["mem.util.cached"] == (58, 0, 13)
-    assert pmid_map["mem.util.bufmem"] == (58, 0, 4)
-    assert pmid_map["mem.physmem"] == (58, 0, 0)
+    assert pmid_map["mem.util.used"] == (60, 1, 1)
+    assert pmid_map["mem.util.free"] == (60, 1, 2)
+    assert pmid_map["mem.util.cached"] == (60, 1, 5)
+    assert pmid_map["mem.util.bufmem"] == (60, 1, 4)
+    assert pmid_map["mem.physmem"] == (60, 1, 0)
 
 
 def test_metric_descriptors_semantics():
@@ -250,14 +250,14 @@ def test_new_memory_metric_pmids():
     hw = make_hw()
     model = make_model()
     desc = {d.name: d for d in model.metric_descriptors(hw)}
-    assert desc["mem.util.active"].pmid == (58, 0, 15)
-    assert desc["mem.util.inactive"].pmid == (58, 0, 16)
-    assert desc["mem.util.slab"].pmid == (58, 0, 12)
-    assert desc["swap.used"].pmid == (58, 1, 0)
-    assert desc["swap.pagesin"].pmid == (58, 1, 1)
-    assert desc["swap.pagesout"].pmid == (58, 1, 2)
-    assert desc["mem.vmstat.pgpgin"].pmid == (58, 2, 0)
-    assert desc["mem.vmstat.pgpgout"].pmid == (58, 2, 1)
+    assert desc["mem.util.active"].pmid == (60, 1, 14)
+    assert desc["mem.util.inactive"].pmid == (60, 1, 15)
+    assert desc["mem.util.slab"].pmid == (60, 1, 25)
+    assert desc["swap.used"].pmid == (60, 1, 7)
+    assert desc["swap.pagesin"].pmid == (60, 0, 8)
+    assert desc["swap.pagesout"].pmid == (60, 0, 9)
+    assert desc["mem.vmstat.pgpgin"].pmid == (60, 28, 0)
+    assert desc["mem.vmstat.pgpgout"].pmid == (60, 28, 1)
 
 
 def test_instant_new_metrics_semantics():

--- a/tests/unit/test_domain_metadata.py
+++ b/tests/unit/test_domain_metadata.py
@@ -139,3 +139,25 @@ def test_compute_returns_all_10_metrics() -> None:
     model = MetadataMetricModel()
     values = model.compute(None, _make_hw(), 60, _make_sampler())
     assert len(values) == 10
+
+
+def test_uname_pmids_match_linux_cluster_12() -> None:
+    """kernel.uname.* must use domain 60, cluster 12, with correct item numbers."""
+    model = MetadataMetricModel()
+    descs = {d.name: d for d in model.metric_descriptors(_make_hw())}
+    assert descs["kernel.uname.sysname"].pmid == (60, 12, 2)
+    assert descs["kernel.uname.nodename"].pmid == (60, 12, 4)
+    assert descs["kernel.uname.release"].pmid == (60, 12, 0)
+    assert descs["kernel.uname.version"].pmid == (60, 12, 1)
+    assert descs["kernel.uname.machine"].pmid == (60, 12, 3)
+    assert descs["kernel.uname.distro"].pmid == (60, 12, 7)
+
+
+def test_hinv_pmids_match_linux_pmda() -> None:
+    """hinv.* PMIDs: physmem/pagesize in CLUSTER_MEMINFO=1, ninterface in CLUSTER_NET_DEV=3."""
+    model = MetadataMetricModel()
+    descs = {d.name: d for d in model.metric_descriptors(_make_hw())}
+    assert descs["hinv.ndisk"].pmid == (60, 0, 33)   # already correct, must not regress
+    assert descs["hinv.physmem"].pmid == (60, 1, 9)
+    assert descs["hinv.pagesize"].pmid == (60, 1, 11)
+    assert descs["hinv.ninterface"].pmid == (60, 3, 27)

--- a/tests/unit/test_domain_system.py
+++ b/tests/unit/test_domain_system.py
@@ -81,7 +81,7 @@ def test_descriptors_include_pswitch(hw4: HardwareProfile) -> None:
     model = SystemMetricModel()
     desc = {d.name: d for d in model.metric_descriptors(hw4)}
     assert "kernel.all.pswitch" in desc
-    assert desc["kernel.all.pswitch"].pmid == (60, 0, 7)
+    assert desc["kernel.all.pswitch"].pmid == (60, 0, 13)
     assert desc["kernel.all.pswitch"].type_code == PM_TYPE_U32
     assert desc["kernel.all.pswitch"].sem == PM_SEM_COUNTER
 

--- a/tests/unit/test_list_metrics.py
+++ b/tests/unit/test_list_metrics.py
@@ -73,7 +73,7 @@ EXPECTED_METRICS: Set[str] = {
     "disk.dev.blkwrite",
     "disk.dev.read_rawactive",
     "disk.dev.write_rawactive",
-    "disk.dev.avg_qlen",
+    "disk.dev.aveq",
     "disk.dev.avactive",
     # New metadata metrics (007)
     "hinv.ndisk",


### PR DESCRIPTION
## Summary

- Fix 47 PMIDs across all 5 domain modules to match real Linux PMDA (`src/pmdas/linux/pmda.c`)
- Eliminate invented domain 58 (memory) — all metrics now use domain 60
- Move disk metrics from invented clusters 4/5 to real `CLUSTER_STAT=0`
- Move percpu metrics from invented cluster 10 to real `CLUSTER_STAT=0`
- Fix metadata: `kernel.uname.*` cluster 9→12, `hinv.physmem/pagesize` to `CLUSTER_MEMINFO=1`
- Rename `disk.dev.avg_qlen` → `disk.dev.aveq` to match real Linux metric name
- Update CLAUDE.md to document alignment approach (replaces "intentionally non-standard" note)

## Domains affected

| Domain | Metrics fixed | Key change |
|--------|--------------|------------|
| CPU | 6 | idle/nice/steal items, percpu cluster 10→0 |
| System | 1 | pswitch item 7→13 |
| Disk | 16 | clusters 4/5→0, all items, avg_qlen→aveq rename |
| Memory | 13 | domain 58→60, clusters realigned |
| Metadata | 9 | uname cluster 9→12, hinv items |

## Test plan

- [ ] All PMID test assertions updated before implementation (TDD)
- [ ] `disk.dev.avg_qlen` → `disk.dev.aveq` renamed in code, CLI, and all tests
- [ ] 463 unit/integration + 7 E2E tests green
- [ ] ruff, mypy, mandoc all clean
- [ ] `./pre-commit.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)